### PR TITLE
Fix base image to have all the required libraries (missing libasound) and adapt docker compose new restrictions on volumes

### DIFF
--- a/Studio/Dockerfile
+++ b/Studio/Dockerfile
@@ -1,7 +1,7 @@
 # Base image with OS and dependencies
 # The base image does NOT include the Hackolade Studio application, which instead gets downloaded as part of the operations below
 # Note that the application is only certified to run in Docker for version 5.1.0 (and above) when adjustments were made for this purpose.
-FROM hackolade/studio:0.0.18
+FROM hackolade/studio:0.0.21
 
 # The latest version of Hackolade will be automatically downloaded and installed by default.
 # A build argument HACKOLADE_URL is defined ***in the parent image*** as an ONBUILD ARG hook and leveraged in /usr/bin/install-hackolade.sh at build time.
@@ -66,11 +66,6 @@ FROM hackolade/studio:0.0.18
 #
 # ADD ./plugins/SQLServer-0.1.60.tar.gz /home/hackolade/.hackolade/plugins/
 # RUN mv /home/hackolade/.hackolade/plugins/SQLServer-0.1.60 /home/hackolade/.hackolade/plugins/SQLServer
-
-#
-# Some programs needed for installation application and plugins are not required at runtime, and are removed from the image
-#
-RUN apt remove curl unzip zip -y && apt autoclean
 
 USER hackolade
 

--- a/Studio/README.md
+++ b/Studio/README.md
@@ -138,7 +138,7 @@ Assuming that a valid Hackolade model file called *`model.json`* is placed in th
         --name hackolade-data-extractor \
         -u root \
         -v hackolade-studio-output:/output \
-        -v ./output:/output-on-host \
+        -v ${PWD}/output:/output-on-host \
         --entrypoint cp \
       hackolade:latest -r /output /output-on-host/. 
     ```
@@ -149,7 +149,7 @@ Assuming that a valid Hackolade model file called *`model.json`* is placed in th
         --name hackolade-data-extractor \
         -u root \
         -v hackolade-studio-logs:/logs \
-        -v ./logs:/logs-on-host \
+        -v ${PWD}/logs:/logs-on-host \
         --entrypoint cp \
       hackolade:latest -r /logs /logs-on-host/. 
     ```
@@ -163,7 +163,7 @@ You may have customized the behavior of the application GUI, and wish to use the
 
 If the containers will be running on a machine with no Hackolade Studio GUI, you use in the [docker-compose.yml](docker-compose.yml) file the default subfolder of the location where the containers will be running:
 
-         - ./options:/home/hackolade/.hackolade/options
+         - ${PWD}/options:/home/hackolade/.hackolade/options
 
 Or you may reference an absolute path to the location of these files, if you're also running the Hackolade Studio GUI on the same Windows machine:
 

--- a/Studio/doc/license-validation.md
+++ b/Studio/doc/license-validation.md
@@ -35,7 +35,7 @@ If your server has no Internet connection, it is necessary to do an offline vali
 4. Validate the license key the command in the SAME image as was used in step 1 while providing the LicenseFile.xml to the container, here with a bind mount in the following example.
 
    ```bash
-    docker compose run --rm -v ./LicenseFile.xml:/licenseFile.xml hackoladeStudioCLI validatekey \
+    docker compose run --rm -v ${PWD}/LicenseFile.xml:/LicenseFile.xml hackoladeStudioCLI validatekey \
         --key=<concurrent-license-key> \
         --file=/LicenseFile.xml
     ```

--- a/Studio/docker-compose.yml
+++ b/Studio/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     - hackolade-studio-logs:/home/hackolade/Documents/HackoladeLogs
     - hackolade-studio-output:/home/hackolade/Documents/output
     # Provide models or inputs from the host (but can be done through named volumes too)
-    - ./models:/home/hackolade/Documents/models
+    - ${PWD}/models:/home/hackolade/Documents/models
     # If you have custom options to configure Hackolade like naming conventions or custom properties uncomment the following line
     #  - ./options:/home/hackolade/.hackolade/options
 


### PR DESCRIPTION
# Context

- Runtime image was missing a library since a recent Electron version to which we upgraded studio (33)
- It appears docker compose doesn't support relative volumes mounts with `./` anymore, we have to provide absolute paths (older version of compose still accept it but it was already brittle under certain scenarios).
- Fixes some documentation typos