### PR TITLE
docs(hck-cli): polish guides hub, QLM URL flow, and compose --rm guidance (HCK-17257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ This repository provides **ready-to-use examples** for the pre-built [`hackolade
 
 All examples and compose files live under **[`Studio/`](./Studio)**.
 
-## Writable paths — `/data` and `/tmp` only
+## Writable paths — `/data` and `/tmp` (recommended)
 
-The **`hackolade/hck-cli`** image writes runtime data to **exactly two locations** and **nowhere else**:
+The **`hackolade/hck-cli`** image steers **runtime writes** to **`/data`** and **`/tmp`** via XDG environment variables:
 
 | Path | Mount | Purpose |
 | --- | --- | --- |
 | **`/data`** | Volume or PVC | License, logs, models, output, settings — everything that must persist |
 | **`/tmp`** | tmpfs / memory `emptyDir` | Sockets, caches, scratch — everything ephemeral |
 
-Do **not** mount legacy paths (`/home/hackolade/.config`, `/home/hackolade/Documents/*`, …). The image redirects all writes through `/data` and `/tmp` via XDG environment variables. With a read-only root filesystem, any write outside these two paths **fails**.
+**Use these consolidated mounts** in new deployments (all examples in this repo do). Older layouts under `/home/hackolade/.config` and `/home/hackolade/Documents/*` may still work on a writable root filesystem, but `/data` + `/tmp` is simpler and required for read-only rootfs / Kubernetes.
 
-Details: [Getting started — runtime model](./Studio/doc/getting-started-hck-cli.md#writable-paths-data-and-tmp-only).
+Details: [Getting started — writable paths](./Studio/doc/getting-started-hck-cli.md#writable-paths-data-and-tmp-recommended).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,23 +4,24 @@ This repository provides **ready-to-use examples** for the pre-built [`hackolade
 
 ![Docker Image Version (latest by date)](https://img.shields.io/docker/v/hackolade/hck-cli)
 
-**Start here:** [Getting started with hackolade/hck-cli](./Studio/doc/getting-started-hck-cli.md)
+All examples and compose files live under **[`Studio/`](./Studio)**.
 
-## Runtime model
+## Documentation
 
-All examples use the **same two write paths** (whether or not the root filesystem is read-only):
-
-- **`/data`** — persistent volume or PVC (license, models, output, logs)
-- **`/tmp`** — tmpfs / memory emptyDir (ephemeral scratch)
-
-## Examples in [`Studio/`](./Studio)
-
-| File | Profile |
+| Guide | When to use it |
 | --- | --- |
-| [`compose.yml`](./Studio/compose.yml) | Local — consolidated `/data` + `/tmp` |
-| [`compose.hardened.yml`](./Studio/compose.hardened.yml) | **Hardened** — same mounts + read-only rootfs, dropped caps (CI / production) |
-| [`k8s/`](./Studio/k8s/) | **Kubernetes** — same mounts + Restricted Pod Security Standard |
+| **[Getting started](./Studio/doc/getting-started-hck-cli.md)** | First run — `/data` + `/tmp` mounts, deployment profiles, quick commands |
+| **[Offline pipeline example](./Studio/doc/example-offline-metadata-pipeline.md)** | **Full CI walkthrough** — image upgrade, offline license, revEng → compMod → DDL → docs |
+| **[Docker CLI how-to](./Studio/doc/docker-cli-howto.md)** | `docker run` without Compose (local and hardened) |
+| **[License validation](./Studio/doc/license-validation.md)** | Online / offline floating license |
+| **[Kubernetes](./Studio/k8s/README.md)** | Restricted Pod Security Standard Jobs |
+| **[Custom TLS certificates](./Studio/doc/custom-certificates.md)** | Private CAs in hardened / K8s setups |
 
-## Custom-built images (legacy)
+```bash
+cd Studio
+docker compose -f compose.hardened.yml run --rm hck-cli
+```
 
-Build on [`hackolade/studio`](https://hub.docker.com/r/hackolade/studio/tags) if you need a custom plugin set. That path uses the legacy `/home/hackolade/Documents/*` layout — see [getting-started.md](./Studio/doc/getting-started.md).
+## Legacy custom builds
+
+Need a custom plugin set? Build on [`hackolade/studio`](https://hub.docker.com/r/hackolade/studio/tags) — see [getting-started.md](./Studio/doc/getting-started.md).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ This repository provides **ready-to-use examples** for the pre-built [`hackolade
 
 All examples and compose files live under **[`Studio/`](./Studio)**.
 
+## Writable paths — `/data` and `/tmp` only
+
+The **`hackolade/hck-cli`** image writes runtime data to **exactly two locations** and **nowhere else**:
+
+| Path | Mount | Purpose |
+| --- | --- | --- |
+| **`/data`** | Volume or PVC | License, logs, models, output, settings — everything that must persist |
+| **`/tmp`** | tmpfs / memory `emptyDir` | Sockets, caches, scratch — everything ephemeral |
+
+Do **not** mount legacy paths (`/home/hackolade/.config`, `/home/hackolade/Documents/*`, …). The image redirects all writes through `/data` and `/tmp` via XDG environment variables. With a read-only root filesystem, any write outside these two paths **fails**.
+
+Details: [Getting started — runtime model](./Studio/doc/getting-started-hck-cli.md#writable-paths-data-and-tmp-only).
+
 ## Documentation
 
 | Guide | When to use it |

--- a/Studio/README.md
+++ b/Studio/README.md
@@ -8,13 +8,15 @@ Run the **Hackolade Studio CLI** in Docker — typically in CI/CD pipelines.
 
 Requires [Docker](https://www.docker.com/get-started).
 
-## Writable paths — `/data` and `/tmp` only
+## Writable paths — `/data` and `/tmp` (recommended)
 
-**The image writes runtime data only to `/data` and `/tmp`.** License state, logs, models, output, and settings go under **`/data`**. Sockets, caches, and scratch go to **`/tmp`**. No other path is used for runtime writes — not `/home/hackolade/.config`, not `/home/hackolade/Documents/*`, not anywhere else on the root filesystem.
+**Prefer `/data` + `/tmp`.** License state, logs, models, output, and settings go under **`/data`**; sockets, caches, and scratch go to **`/tmp`**. The image redirects runtime writes there via XDG environment variables.
 
-Mount **both** on every run. With `read_only: true`, writes outside `/data` or `/tmp` fail immediately.
+Legacy bind mounts (`/home/hackolade/.config`, `/home/hackolade/Documents/*`, …) from older examples **can still work** on a writable root filesystem, but the consolidated layout is **recommended** — especially for hardened Compose, read-only rootfs, and Kubernetes.
 
-Full breakdown: [getting-started-hck-cli.md](./doc/getting-started-hck-cli.md#writable-paths-data-and-tmp-only).
+Mount **both** `/data` and `/tmp` on every run. With `read_only: true`, only those two paths are writable.
+
+Full breakdown: [getting-started-hck-cli.md](./doc/getting-started-hck-cli.md#writable-paths-data-and-tmp-recommended).
 
 ## Documentation
 

--- a/Studio/README.md
+++ b/Studio/README.md
@@ -2,340 +2,44 @@
 
 ![Docker Image Version (latest by date)](https://img.shields.io/docker/v/hackolade/hck-cli)
 
-The purpose of running Hackolade in a Docker container is to operate the **Command-Line Interface (CLI)**, typically in CI/CD pipelines.
+Run the **Hackolade Studio CLI** in Docker — typically in CI/CD pipelines.
 
-⚠ The purpose is **not** to run the application GUI in Docker — this is **not** supported.
+⚠ **Not supported:** running the Hackolade GUI in a container.
 
-The instructions below assume Docker is [installed](https://www.docker.com/get-started) and running.
+Requires [Docker](https://www.docker.com/get-started).
 
-## 🚀 Getting started (recommended)
+## Documentation
 
-Use the pre-built [`hackolade/hck-cli`](https://hub.docker.com/r/hackolade/hck-cli/tags) image — Hackolade Studio CLI with all plugins, no build step:
-
-**[Getting started with hackolade/hck-cli](./doc/getting-started-hck-cli.md)** — consolidated writes to `/data` + `/tmp`, hardened Compose, and Kubernetes examples.
-
-**[Example: offline metadata pipeline](./doc/example-offline-metadata-pipeline.md)** — story walkthrough: new image tag, offline license, `version` / `showLicense` / `listLogs` / `showLogs`, revEng → compMod → DDL → docs (hardened Compose).
+| Guide | Description |
+| --- | --- |
+| **[getting-started-hck-cli.md](./doc/getting-started-hck-cli.md)** | Start here — `/data` + `/tmp` layout, profiles, quick start |
+| **[example-offline-metadata-pipeline.md](./doc/example-offline-metadata-pipeline.md)** | **Full worked example** — image upgrade, offline license, `version` / `showLicense` / `listLogs` / `showLogs`, revEng → compMod → forweng → genDoc |
+| **[docker-cli-howto.md](./doc/docker-cli-howto.md)** | `docker run` templates (local and hardened) |
+| **[license-validation.md](./doc/license-validation.md)** | Floating license — online and offline |
+| **[k8s/README.md](./k8s/README.md)** | Kubernetes Jobs (Restricted profile) |
+| **[custom-certificates.md](./doc/custom-certificates.md)** | Trust private CAs |
+| **[getting-started.md](./doc/getting-started.md)** | Legacy — custom-built `hackolade/studio` images |
 
 ```bash
-# Recommended baseline for CI / production (read-only rootfs, same write layout)
-docker compose -f compose.hardened.yml run --rm hck-cli version
+docker compose -f compose.hardened.yml run --rm hck-cli
 ```
 
-## Runtime model
+Always use **`run --rm`** for one-off CLI jobs — without it, stopped `…-run-…` containers pile up and Compose warns about orphans.
 
-Every `hackolade/hck-cli` deployment uses **two writable mounts only**:
+## Compose & manifests
 
-| Mount | Purpose |
+| File | Profile |
 | --- | --- |
-| `/data` | License state, models, output, logs (persistent volume or PVC) |
-| `/tmp` | Sockets, caches, scratch (tmpfs / memory emptyDir) |
+| [compose.yml](./compose.yml) | Local — `/data` + `/tmp`, writable rootfs |
+| [compose.hardened.yml](./compose.hardened.yml) | **Hardened** (CI / production) — read-only rootfs, `cap_drop: ALL` |
+| [k8s/](./k8s/) | Kubernetes — same mounts + Restricted Pod Security Standard |
 
-[`compose.yml`](./compose.yml) and [`compose.hardened.yml`](./compose.hardened.yml) share this layout. Hardened adds read-only root filesystem, dropped capabilities, and non-root execution — the profile used in [`k8s/`](./k8s/) as well.
+## Custom builds (legacy)
 
-## Build your own image (advanced)
+Build your own image when you need a custom plugin set: [build.md](./doc/build.md), [Dockerfile](./Dockerfile), [docker-compose.yml](./docker-compose.yml).
 
-Need a custom plugin set or Dockerfile based on [`hackolade/studio`](https://hub.docker.com/r/hackolade/studio/tags)? See [getting-started.md](./doc/getting-started.md) and [build.md](./doc/build.md).
-
-## Repository structure
-
-Primary examples use the pre-built **`hackolade/hck-cli`** image (same `/data` + `/tmp` write layout in every profile):
-
-- [compose.yml](compose.yml): local Compose — consolidated mounts, writable rootfs
-- [compose.hardened.yml](compose.hardened.yml): **hardened** — same mounts + read-only rootfs, `cap_drop: ALL`
-- [k8s/](k8s/): **Kubernetes** Jobs — same mounts + Restricted Pod Security Standard
-- [doc/docker-cli-howto.md](doc/docker-cli-howto.md): **`docker run`** examples without Compose
-
-Custom-build path (legacy layout on `hackolade/studio`):
-
-- [Dockerfile](Dockerfile): example full installation with selected plugins
-- [docker-compose.yml](docker-compose.yml): Compose for custom-built images
-- [securityPolicies.json](securityPolicies.json) - [optional] the list of required system call operations to be able to run Hackolade with Chrome sandboxing (disabled by default) inside a container ([more details](https://docs.docker.com/engine/security/seccomp/))
-- batch files examples when running on Windows:
-  - [docker-help.bat](docker-help.bat): verify the proper running of the CLI by displaying the CLI help in a container.  Will work without a validated license key.
-  - [docker-validateKey.bat](docker-validateKey.bat): validate a license key
-  - [docker-genDoc.bat](docker-genDoc.bat): run the CLI for the genDoc command.  Requires a validated license key.
-
-
+Windows batch helpers: [docker-help.bat](./docker-help.bat), [docker-validateKey.bat](./docker-validateKey.bat), [docker-genDoc.bat](./docker-genDoc.bat).
 
 ## Licensing
 
-**Important note:**  the Docker CLI requires a **floating** (a.k.a. concurrent) license key with an **available seat**.   If the seat gets validated offline, it remains dedicated to the Docker CLI and is not sharable with other users.  To ensure that your CI/CD pipeline jobs always have an available seat, you may want to get a floating license key dedicated to this purpose.  On a single machine, you may run multiple containers of the same image in parallel with a floating license key.    An individual workstation license of Hackolade is **not** sufficient.  If you just need to run the CLI from an OS command prompt or terminal, you may do so with your regular Professional or Workgroup edition license.
-
-To purchase a floating license subscription, please send an email to support@hackolade.com.
-
-To ensure proper behavior of the Hackolade Studio CLI in a Docker container, make sure to use an Hackolade version v5.1.1 or above.
-
-
-
-## Managing data
-
-Hackolade requires to read and persist data from some specific folders.  There are many ways to manage data in the context of containers using [data volumes](https://docs.docker.com/storage/volumes/).
-
-For security reasons and following best practices for running containers, Hackolade will run using a dedicated yet **unprivileged** user: **hackolade**.
-
-For portability reasons, we advise to use Docker named volumes for folders where Hackolade is writing as much as possible instead of bind mounts from the host.  It deeply simplifies the requirements for running Hackolade Docker image.  This is especially true for the two operational folders **appData** and **HackoladeLogs** as well as for the folder Hackolade will generate output artifacts, like results of forward engineering commands.
-
-In general, reading data out of any folder should likely work out of the box because our **hackolade** user is having **GID 0**, but for writing data the target folder should be writable by our **hackolade** user.
-
-We advise to separate input folders (read by Hackolade Studio) from output folders to simplify operations.
-
-### hackolade user inside containers
-The **hackolade** user pre-configured inside the image has the following UID/GID that you can use to properly configure the folders and files permissions on the host:
-
-- UID: 1000
-- GID: 0
-
-
-
-### Required directories (inside containers)
-
-#### Pre-built `hackolade/hck-cli` image (recommended)
-
-The image expects a **read-only root filesystem** with exactly two writable mounts:
-
-- **`/data`** (persistent volume): license/userData under `/data/app`, plus logs, models, output, settings, and options
-- **`/tmp`** (tmpfs): sockets, caches, and scratch files
-
-See [`doc/getting-started-hck-cli.md`](./doc/getting-started-hck-cli.md) and [`compose.yml`](./compose.yml). Custom CAs use read-only PEM mounts and `NODE_EXTRA_CA_CERTS` / `SSL_CERT_FILE` — see [`doc/custom-certificates.md`](./doc/custom-certificates.md).
-
-For hardened deployments, see [`compose.hardened.yml`](./compose.hardened.yml) and [`k8s/`](./k8s/).
-
-**Breaking change:** do not mount `/home/hackolade/.config` for the pre-built image; that path is no longer used for license state.
-
-#### Custom-built `hackolade/studio` images
-
-Older custom builds may still use the historical layout:
-
-- `/home/hackolade/.config/Hackolade`: application data (**appData**) — must be readable and writable by the container user
-- `/home/hackolade/Documents/HackoladeLogs`: logging information
-- `/home/hackolade/Documents/data`: generated artifacts (models, documentation, RE/FE outputs, etc.)
-- [Optional] `/home/hackolade/.hackolade/options`: user-defined configurations
-
-Prefer migrating custom images to the `/data` + `/tmp` model used by `hackolade/hck-cli`.
-
-
-You must create manually the folders you will bind mount prior to running hackolade studio containers because docker doesn't create them automatically anymore.
-
-#### File permissions and bind mounts
-
-Any pre-existing data in the Docker image in the bind mounted folders will be **erased and overridde**n** by the data present on the host folder.  Docker will use the user owning the folder on the host as the owner of all the files of target directory where the bind mount is done.  Therefore, the unprivileged **hackolade** user inside the container (note that Hackolade CLI can not be run as *root***) must have enough permissions to write and read from these host folders.
-
-
-##### Example how to set permissions on host folder
-
-```bash
-mkdir -p $PWD/models $PWD/hackolade-options
-chown -R 1000:0 $PWD/models $PWD/hackolade-options
-```
-
-
-
-## Build the image
-
-The very first step is to fetch the base image from our [Docker Hub latest tag](https://hub.docker.com/r/hackolade/studio/tags).
-
-Then you must build your Docker image with the Hackolade Studio application version and the plugins that you want to use.  Follow instructions details in [this page](./doc/build.md).
-
-Once you have built the Docker image you need to first validate your floating license for that new image before being able to run the Hackolade CLI with your scenario of choice.
-
-### Validate license key for the image
-
-Follow the fully detailed instructions in [this page](./doc/license-validation.md).
-
-**Note:** The license key validation must be repeated for each new Docker image.
-
-
-
-## Run Hackolade CLI in a container
-
-You can run Hackolade CLI commands using either **Docker CLI directly** or **Docker Compose**. Both approaches are fully supported and documented.
-
-### Using Docker Compose (Recommended for simplicity)
-
-Docker Compose uses the [docker-compose.yml](docker-compose.yml) file to manage volumes and configuration automatically, resulting in shorter commands.
-
-A typical command:
-```bash
-docker compose run --rm hackoladeStudioCLI command [--arguments]
-```
-
-where:
-- `hackoladeStudioCLI` is the name of the service as defined in docker-compose.yml
-- `command` is the CLI command
-- `--arguments` is for optional arguments
-
-Example:
-```bash
-docker compose run --rm hackoladeStudioCLI help
-```
-
-### Using Docker CLI Directly
-
-If you prefer explicit control or want to understand exactly what's happening, you can use Docker CLI commands directly:
-
-```bash
-docker run --rm \
-  -v hackolade-studio-app-data:/home/hackolade/.config/Hackolade \
-  -v hackolade-studio-logs:/home/hackolade/Documents/HackoladeLogs \
-  -v hackolade-studio-output:/home/hackolade/Documents/output \
-  -v ${PWD}/models:/home/hackolade/Documents/models \
-  -w /home/hackolade/Documents \
-  hackolade:latest command [--arguments]
-```
-
-Example:
-```bash
-docker run --rm \
-  -v hackolade-studio-app-data:/home/hackolade/.config/Hackolade \
-  -v hackolade-studio-logs:/home/hackolade/Documents/HackoladeLogs \
-  -v hackolade-studio-output:/home/hackolade/Documents/output \
-  -v ${PWD}/models:/home/hackolade/Documents/models \
-  -w /home/hackolade/Documents \
-  hackolade:latest help
-```
-
-**For detailed instructions and more examples, see the [Getting Started Guide](./doc/getting-started.md).**
-
-You may consult our [online documentation](https://hackolade.com/help/CommandLineInterface.html) for the full description of commands and their respective arguments.
-
-
-
-## Example Scenario: Generate documentation and forward-engineer for a model
-
-This example shows how to generate documentation and forward-engineer a model. We provide both **Docker CLI** and **Docker Compose** versions.
-
-Assuming that a valid Hackolade model file called *`model.json`* is placed in the *`models`* subfolder of the location where the container is being run:
-
-### Step 1: Build the docker image
-
-Both methods use the same build command:
-```bash
-docker build --no-cache --pull -t hackolade:latest .
-```
-
-### Step 2: Validate the license
-
-**Using Docker Compose:**
-```bash
-docker compose run --rm hackoladeStudioCLI validatekey \
-        --key=<floating-license-key> \
-        --identifier=$(docker compose run --rm --entrypoint show-computer-id.sh hackoladeStudioCLI)
-```
-
-**Using Docker CLI:**
-```bash
-# First, get the computer ID
-UUID=$(docker run --rm --entrypoint show-computer-id.sh hackolade:latest)
-
-# Then validate the license
-docker run --rm \
-  -v hackolade-studio-app-data:/home/hackolade/.config/Hackolade \
-  hackolade:latest validatekey \
-  --key=<floating-license-key> \
-  --identifier=$UUID
-```
-
-For detailed license validation instructions (including offline), see [license-validation.md](./doc/license-validation.md).
-
-### Step 3: Generate documentation
-
-**Using Docker Compose:**
-```bash
-docker compose run --rm hackoladeStudioCLI genDoc \
-  --model=/home/hackolade/Documents/models/model.json \
-  --format=HTML --doc=/home/hackolade/Documents/output/doc.html
-```
-
-**Using Docker CLI:**
-```bash
-docker run --rm \
-  -v hackolade-studio-app-data:/home/hackolade/.config/Hackolade \
-  -v hackolade-studio-logs:/home/hackolade/Documents/HackoladeLogs \
-  -v hackolade-studio-output:/home/hackolade/Documents/output \
-  -v ${PWD}/models:/home/hackolade/Documents/models \
-  -w /home/hackolade/Documents \
-  hackolade:latest genDoc \
-  --model=/home/hackolade/Documents/models/model.json \
-  --format=HTML --doc=/home/hackolade/Documents/output/doc.html
-```
-
-### Step 4: Forward engineer the model
-
-**Using Docker Compose:**
-```bash
-docker compose run --rm hackoladeStudioCLI forweng \
-    --model model.json \
-    --jsonschemacompliance full \
-    --skipUndefinedLevel \
-    --structuredpath false \
-    --path /home/hackolade/Documents/output/ \
-    --outputtype jsonschema
-```
-
-**Using Docker CLI:**
-```bash
-docker run --rm \
-  -v hackolade-studio-app-data:/home/hackolade/.config/Hackolade \
-  -v hackolade-studio-logs:/home/hackolade/Documents/HackoladeLogs \
-  -v hackolade-studio-output:/home/hackolade/Documents/output \
-  -v ${PWD}/models:/home/hackolade/Documents/models \
-  -w /home/hackolade/Documents \
-  hackolade:latest forweng \
-  --model model.json \
-  --jsonschemacompliance full \
-  --skipUndefinedLevel \
-  --structuredpath false \
-  --path /home/hackolade/Documents/output/ \
-  --outputtype jsonschema
-```
-
-### Step 5: Retrieve generated files
-
-Both methods use the same commands to extract files from Docker volumes:
-
-**Retrieve output files:**
-```bash
-docker run --rm --init \
-    --name hackolade-data-extractor \
-    -u root \
-    -v hackolade-studio-output:/output \
-    -v ${PWD}/output:/output-on-host \
-    --entrypoint cp \
-  hackolade:latest -r /output /output-on-host/.
-```
-
-**Retrieve log files:**
-```bash
-docker run --rm --init \
-    --name hackolade-log-extractor \
-    -u root \
-    -v hackolade-studio-logs:/logs \
-    -v ${PWD}/logs:/logs-on-host \
-    --entrypoint cp \
-  hackolade:latest -r /logs /logs-on-host/.
-```
-
-**For more examples and detailed explanations, see the [Getting Started Guide](./doc/getting-started.md).**
-
-This example can be adjusted to run any CLI command, as documented [here](https://hackolade.com/help/CommandLineInterface.html).
-
-
-### Custom properties, naming conventions, Excel export options
-
-You may have customized the behavior of the application GUI, and wish to use them during CLI processing.
-
-If the containers will be running on a machine with no Hackolade Studio GUI, you use in the [docker-compose.yml](docker-compose.yml) file the default subfolder of the location where the containers will be running:
-
-         - ${PWD}/options:/home/hackolade/.hackolade/options
-
-Or you may reference an absolute path to the location of these files, if you're also running the Hackolade Studio GUI on the same Windows machine:
-
-```Windows
-     - C:/Users/%username%/.hackolade/options:/home/hackolade/.hackolade/options
-```
-
-
-
-## Running the CLI from GitHub Actions based on a trigger
-
-Take a look at [this repository](https://github.com/hackolade/studio-cli-github-actions-examples) for such an illustration.
+Docker CLI requires a **floating** license with an available seat. Workstation licenses do not work in containers. See [license-validation.md](./doc/license-validation.md). Contact support@hackolade.com to purchase.

--- a/Studio/README.md
+++ b/Studio/README.md
@@ -8,6 +8,14 @@ Run the **Hackolade Studio CLI** in Docker — typically in CI/CD pipelines.
 
 Requires [Docker](https://www.docker.com/get-started).
 
+## Writable paths — `/data` and `/tmp` only
+
+**The image writes runtime data only to `/data` and `/tmp`.** License state, logs, models, output, and settings go under **`/data`**. Sockets, caches, and scratch go to **`/tmp`**. No other path is used for runtime writes — not `/home/hackolade/.config`, not `/home/hackolade/Documents/*`, not anywhere else on the root filesystem.
+
+Mount **both** on every run. With `read_only: true`, writes outside `/data` or `/tmp` fail immediately.
+
+Full breakdown: [getting-started-hck-cli.md](./doc/getting-started-hck-cli.md#writable-paths-data-and-tmp-only).
+
 ## Documentation
 
 | Guide | Description |

--- a/Studio/compose.hardened.yml
+++ b/Studio/compose.hardened.yml
@@ -21,7 +21,9 @@
 #   /tmp   tmpfs — sockets, caches, scratch
 #
 # Usage:
-#   docker compose -f compose.hardened.yml run --rm hck-cli version
+#   docker compose -f compose.hardened.yml run --rm hck-cli
+#   (--rm removes the one-off container; omitting it leaves orphan …-run-… containers)
+#   Default command is version — lists Studio release and installed plugins
 #
 # For the same /data + /tmp layout without read-only rootfs, use compose.yml.
 # For Kubernetes manifests with a PVC, see k8s/hck-cli-job.yaml.
@@ -47,6 +49,7 @@ services:
 
   showComputerIdForOfflineValidation:
     extends: hck-cli
+    # Prints Computer ID + ready-to-open QLM URL for LicenseFile.xml download
     command: ["getComputerId"]
 
   validateKeyOffline:

--- a/Studio/compose.hardened.yml
+++ b/Studio/compose.hardened.yml
@@ -9,11 +9,11 @@
 
 # Hardened Docker Compose example for hackolade/hck-cli.
 #
-# WRITABLE PATHS: /data and /tmp ONLY — the image writes runtime data nowhere else.
+# WRITABLE PATHS: /data and /tmp (consolidated mounts — recommended).
 #   /data  persistent volume — license (/data/app), logs, models, output, settings
 #   /tmp   tmpfs — sockets, caches, scratch
-# read_only: true enforces this: any write outside /data or /tmp fails.
-# Do not mount legacy /home/hackolade/.config or /home/hackolade/Documents/* paths.
+# read_only: true allows writes only on /data and /tmp.
+# Legacy /home/hackolade/… bind mounts are not needed; prefer /data subpaths.
 #
 # Security profile (CI, production, Kubernetes Restricted parity):
 #   - read-only root filesystem

--- a/Studio/compose.hardened.yml
+++ b/Studio/compose.hardened.yml
@@ -9,16 +9,16 @@
 
 # Hardened Docker Compose example for hackolade/hck-cli.
 #
-# Same consolidated write layout as compose.yml (/data + /tmp). This file adds the
-# security profile expected in CI, production, and Kubernetes Restricted:
+# WRITABLE PATHS: /data and /tmp ONLY — the image writes runtime data nowhere else.
+#   /data  persistent volume — license (/data/app), logs, models, output, settings
+#   /tmp   tmpfs — sockets, caches, scratch
+# read_only: true enforces this: any write outside /data or /tmp fails.
+# Do not mount legacy /home/hackolade/.config or /home/hackolade/Documents/* paths.
 #
+# Security profile (CI, production, Kubernetes Restricted parity):
 #   - read-only root filesystem
 #   - all capabilities dropped, no privilege escalation
 #   - non-root user (1000:1001 by default)
-#
-# Writable mounts (always the same two paths):
-#   /data  persistent volume — license state, logs, models, output, settings
-#   /tmp   tmpfs — sockets, caches, scratch
 #
 # Usage:
 #   docker compose -f compose.hardened.yml run --rm hck-cli

--- a/Studio/compose.yml
+++ b/Studio/compose.yml
@@ -10,10 +10,11 @@
 # Example Docker Compose file for the pre-built hackolade/hck-cli image from Docker Hub.
 # The image includes Hackolade Studio and all plugins — ready to use without a build step.
 #
-# WRITABLE PATHS: /data and /tmp ONLY — the image writes runtime data nowhere else.
+# WRITABLE PATHS: prefer /data and /tmp (consolidated mounts).
 #   /data  persistent volume — license (/data/app), logs, models, output, settings
 #   /tmp   tmpfs — sockets, caches, scratch (ephemeral)
-# Do not mount legacy /home/hackolade/.config or /home/hackolade/Documents/* paths.
+# Legacy /home/hackolade/.config and /home/hackolade/Documents/* may still work
+# on a writable rootfs, but use /data + /tmp for new setups (see getting-started-hck-cli.md).
 #
 # Same two paths in compose.hardened.yml and k8s/ — hardened adds read-only rootfs + caps.
 #

--- a/Studio/compose.yml
+++ b/Studio/compose.yml
@@ -20,6 +20,8 @@
 #
 # Documentation: doc/getting-started-hck-cli.md
 # Custom builds on hackolade/studio: docker-compose.yml + doc/getting-started.md
+#
+# Usage: docker compose run --rm …  (always --rm for one-off CLI jobs)
 
 services:
   # Run a CLI command (defaults to version).
@@ -45,6 +47,7 @@ services:
 
   showComputerIdForOfflineValidation:
     extends: hck-cli
+    # Prints Computer ID + ready-to-open QLM URL for LicenseFile.xml download
     command: ["getComputerId"]
 
   # validateKeyOfflineFromFile:

--- a/Studio/compose.yml
+++ b/Studio/compose.yml
@@ -10,13 +10,12 @@
 # Example Docker Compose file for the pre-built hackolade/hck-cli image from Docker Hub.
 # The image includes Hackolade Studio and all plugins — ready to use without a build step.
 #
-# Runtime writes are consolidated to exactly two mounts (same layout as compose.hardened.yml
-# and the k8s/ manifests — only the security profile differs here):
-#   /data  persistent volume — license state, logs, models, output, settings
-#   /tmp   tmpfs — sockets, caches, scratch
+# WRITABLE PATHS: /data and /tmp ONLY — the image writes runtime data nowhere else.
+#   /data  persistent volume — license (/data/app), logs, models, output, settings
+#   /tmp   tmpfs — sockets, caches, scratch (ephemeral)
+# Do not mount legacy /home/hackolade/.config or /home/hackolade/Documents/* paths.
 #
-# For read-only root filesystem, dropped capabilities, and Kubernetes Restricted parity,
-# use compose.hardened.yml instead.
+# Same two paths in compose.hardened.yml and k8s/ — hardened adds read-only rootfs + caps.
 #
 # Documentation: doc/getting-started-hck-cli.md
 # Custom builds on hackolade/studio: docker-compose.yml + doc/getting-started.md

--- a/Studio/doc/docker-cli-howto.md
+++ b/Studio/doc/docker-cli-howto.md
@@ -2,7 +2,7 @@
 
 Use this guide when you prefer **`docker run`** over Compose.
 
-> **Writable paths:** mount **`/data`** (volume) and **`/tmp`** (tmpfs) only. The image writes runtime data **nowhere else** — see [getting-started-hck-cli.md](./getting-started-hck-cli.md#writable-paths-data-and-tmp-only).
+> **Recommended mounts:** **`/data`** (volume) and **`/tmp`** (tmpfs). The image steers runtime writes there. Legacy `/home/hackolade/…` paths may still work on a writable rootfs, but prefer the consolidated layout — see [getting-started-hck-cli.md](./getting-started-hck-cli.md#writable-paths-data-and-tmp-recommended).
 
 Every example below includes both mounts.
 

--- a/Studio/doc/docker-cli-howto.md
+++ b/Studio/doc/docker-cli-howto.md
@@ -1,0 +1,85 @@
+# Docker CLI how-to (`docker run`)
+
+Use this guide when you prefer **`docker run`** over Compose. The same **`/data` + `/tmp`** write layout applies — see [getting-started-hck-cli.md](./getting-started-hck-cli.md).
+
+For a full end-to-end pipeline (offline license, revEng, compMod, forweng, genDoc), see **[example-offline-metadata-pipeline.md](./example-offline-metadata-pipeline.md)**.
+
+Pin the image tag (example: `hackolade/hck-cli:8.12.7`). `latest` is not published.
+
+## Local profile
+
+Writable root filesystem — minimal flags. Pass **`version`** explicitly with `docker run` (Compose sets it as the default service command):
+
+```bash
+docker volume create hackolade-studio-data
+
+docker run --rm \
+  -v hackolade-studio-data:/data \
+  -v "${PWD}/models:/data/models" \
+  --tmpfs /tmp:rw,size=1g,mode=1777 \
+  hackolade/hck-cli:8.12.7 version
+```
+
+Expect `Hackolade version: …` and an `Installed plugins (N):` list (name, version, commit, build date per plugin).
+
+## Hardened profile (CI / production)
+
+Read-only root filesystem, non-root, dropped capabilities — mirrors [`compose.hardened.yml`](../compose.hardened.yml):
+
+```bash
+docker run --rm \
+  --init \
+  --read-only \
+  --user 1000:1001 \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  -v hackolade-studio-data:/data \
+  -v "${PWD}/models:/data/models" \
+  --tmpfs /tmp:rw,size=1g,mode=1777 \
+  hackolade/hck-cli:8.12.7 version
+```
+
+## Diagnostics
+
+Wrapper commands — no full Studio session:
+
+```bash
+docker run --rm ... hackolade/hck-cli:8.12.7 showLicense
+docker run --rm ... hackolade/hck-cli:8.12.7 showLicense --json
+docker run --rm ... hackolade/hck-cli:8.12.7 listLogs
+docker run --rm ... hackolade/hck-cli:8.12.7 showLogs <runId> --tail 50 --logfile re
+```
+
+Replace `...` with the same volume and security flags as above. Details: [getting-started-hck-cli.md](./getting-started-hck-cli.md#inspecting-the-image-license-and-logs).
+
+## Run a CLI command
+
+```bash
+docker run --rm \
+  --init --read-only --user 1000:1001 --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  -v hackolade-studio-data:/data \
+  -v "${PWD}/models:/data/models" \
+  --tmpfs /tmp:rw,size=1g,mode=1777 \
+  hackolade/hck-cli:8.12.7 genDoc \
+  --format=HTML \
+  --model /data/models/my-model.hck.json \
+  --doc /data/output/doc
+```
+
+## Copy artifacts from the volume
+
+```bash
+mkdir -p ./artifacts
+docker run --rm --user root \
+  -v hackolade-studio-data:/data:ro \
+  -v "${PWD}/artifacts:/host" \
+  --entrypoint cp \
+  hackolade/hck-cli:8.12.7 -r /data/output/. /host/
+```
+
+## See also
+
+- [Getting started with hck-cli](./getting-started-hck-cli.md)
+- [Example: offline metadata pipeline](./example-offline-metadata-pipeline.md)
+- [License validation](./license-validation.md)

--- a/Studio/doc/docker-cli-howto.md
+++ b/Studio/doc/docker-cli-howto.md
@@ -1,6 +1,10 @@
 # Docker CLI how-to (`docker run`)
 
-Use this guide when you prefer **`docker run`** over Compose. The same **`/data` + `/tmp`** write layout applies — see [getting-started-hck-cli.md](./getting-started-hck-cli.md).
+Use this guide when you prefer **`docker run`** over Compose.
+
+> **Writable paths:** mount **`/data`** (volume) and **`/tmp`** (tmpfs) only. The image writes runtime data **nowhere else** — see [getting-started-hck-cli.md](./getting-started-hck-cli.md#writable-paths-data-and-tmp-only).
+
+Every example below includes both mounts.
 
 For a full end-to-end pipeline (offline license, revEng, compMod, forweng, genDoc), see **[example-offline-metadata-pipeline.md](./example-offline-metadata-pipeline.md)**.
 

--- a/Studio/doc/example-offline-metadata-pipeline.md
+++ b/Studio/doc/example-offline-metadata-pipeline.md
@@ -4,7 +4,7 @@
 
 End-to-end story using [`compose.hardened.yml`](../compose.hardened.yml): a new `hackolade/hck-cli` image is available, your runner has **no Internet**, and you want to refresh a production model, diff it against a baseline, then publish **DDL** and **documentation**.
 
-Every step uses the hardened profile (read-only rootfs, `/data` + `/tmp` tmpfs). The `hck-cli` wrapper also provides **`version`**, **`showLicense`**, **`listLogs`**, and **`showLogs`** — useful to confirm what is installed, whether the license matches the current image, and what happened when a command fails.
+Every step uses the hardened profile (read-only rootfs). **All runtime writes go only to `/data` (volume) and `/tmp` (tmpfs)** — nowhere else on the filesystem.
 
 ```bash
 cd /path/to/docker/Studio

--- a/Studio/doc/example-offline-metadata-pipeline.md
+++ b/Studio/doc/example-offline-metadata-pipeline.md
@@ -4,7 +4,7 @@
 
 End-to-end story using [`compose.hardened.yml`](../compose.hardened.yml): a new `hackolade/hck-cli` image is available, your runner has **no Internet**, and you want to refresh a production model, diff it against a baseline, then publish **DDL** and **documentation**.
 
-Every step uses the hardened profile (read-only rootfs). **All runtime writes go only to `/data` (volume) and `/tmp` (tmpfs)** — nowhere else on the filesystem.
+Every step uses the hardened profile (read-only rootfs) with **consolidated `/data` + `/tmp` mounts** (recommended over legacy `/home/hackolade/…` paths).
 
 ```bash
 cd /path/to/docker/Studio

--- a/Studio/doc/example-offline-metadata-pipeline.md
+++ b/Studio/doc/example-offline-metadata-pipeline.md
@@ -1,5 +1,7 @@
 # Example: offline license + metadata pipeline (hardened Compose)
 
+**Part of:** [Getting started](./getting-started-hck-cli.md) · [All guides](../README.md#documentation)
+
 End-to-end story using [`compose.hardened.yml`](../compose.hardened.yml): a new `hackolade/hck-cli` image is available, your runner has **no Internet**, and you want to refresh a production model, diff it against a baseline, then publish **DDL** and **documentation**.
 
 Every step uses the hardened profile (read-only rootfs, `/data` + `/tmp` tmpfs). The `hck-cli` wrapper also provides **`version`**, **`showLicense`**, **`listLogs`**, and **`showLogs`** — useful to confirm what is installed, whether the license matches the current image, and what happened when a command fails.
@@ -7,6 +9,7 @@ Every step uses the hardened profile (read-only rootfs, `/data` + `/tmp` tmpfs).
 ```bash
 cd /path/to/docker/Studio
 export COMPOSE="docker compose -f compose.hardened.yml"
+# Always: $COMPOSE run --rm <service> …  (--rm avoids orphan container warnings)
 ```
 
 ---
@@ -49,10 +52,21 @@ $COMPOSE pull
 ### What is installed?
 
 ```bash
-$COMPOSE run --rm hck-cli version
+$COMPOSE run --rm hck-cli
 ```
 
-Confirms the Studio/CLI build inside the container (expect **`8.12.7`** after you updated the compose file).
+The default command is **`version`**. Output includes the Studio release and every bundled plugin:
+
+```text
+Hackolade version: 8.12.7
+
+Installed plugins (40):
+  Avro: 0.2.27, commit: d0fda00f, built: 2026-07-03T13:26:23+0000
+  BigQuery: 0.2.30, commit: 04fb1148, built: 2026-08-07T09:04:23+0000
+  …
+```
+
+Expect **`8.12.7`** after you update the image tag in the compose file.
 
 ### Is the license ready for this image?
 
@@ -76,19 +90,33 @@ Exit code `0` means installed and healthy; `1` means missing, partial, or expire
 
 Each image tag has its own container UUID. Upgrading **`8.9.2` → `8.12.7`** requires a new offline activation even if the floating key is unchanged.
 
-### 1a. Computer ID (air-gapped server)
+### 1a. Computer ID + QLM URL (air-gapped server)
 
 ```bash
 $COMPOSE run --rm showComputerIdForOfflineValidation
 ```
 
-Copy the UUID (suffix `-docker`).
+The service runs **`getComputerId`**. Example output:
 
-### 1b. Generate `LicenseFile.xml` (Internet-connected machine)
+```text
+📋 Copy the Computer ID below and use it for offline license activation:
 
-Use [Hackolade QLM customer site](https://quicklicensemanager.com/hackolade/QlmCustomerSite) with your floating key and the computer ID. Download **`LicenseFile.xml`** unchanged.
+afa10d9e-17cd-48d7-97f5-b277951773ec-b572e4e5-6796-4cf7-820e-62a30530a318-8.12.7-docker
 
-Place it where `compose.hardened.yml` expects it:
+🌐 Open the following URL in your browser to proceed with offline validation:
+   https://quicklicensemanager.com/hackolade/qlmcustomersite/qlmwebactivation.aspx?is_file=1&is_pcid=afa10d9e-17cd-48d7-97f5-b277951773ec-b572e4e5-6796-4cf7-820e-62a30530a318-8.12.7-docker&is_avkey=YOUR-FLOATING-LICENSE-KEY
+   (activation key prefilled from license key / secrets)
+```
+
+The Computer ID encodes the **image UUID**, **container UUID**, **Studio version**, and a **`-docker`** suffix. The QLM URL is ready to use: **`is_file=1`** triggers **`LicenseFile.xml`** download, **`is_pcid`** is prefilled with the Computer ID, and **`is_avkey`** is prefilled when the `license_key` secret is configured in compose — open the link on a connected machine and confirm; no manual form fill needed.
+
+### 1b. Download `LicenseFile.xml` (Internet-connected machine)
+
+Open the URL from step 1a in a browser on any machine with Internet access. QLM downloads **`LicenseFile.xml`** automatically — no need to fill the form manually when the URL is complete.
+
+**Do not edit** the downloaded file.
+
+Copy it to the path expected by `compose.hardened.yml`:
 
 ```yaml
 secrets:
@@ -227,7 +255,7 @@ docker run --rm --user root \
 
 | Command | Purpose |
 | --- | --- |
-| `version` | Studio/CLI build in the image |
+| `version` | Studio release + full plugin inventory (name, version, commit, build date) |
 | `showLicense` | License installed? Matches current image? (`--json` for CI) |
 | `listLogs` | List command runs under `/data/logs` (newest first) |
 | `showLogs [runId] [--tail N] [--logfile main\|re\|fe\|license]` | Tail logs for one run |
@@ -235,7 +263,7 @@ docker run --rm --user root \
 All are **`hck-cli` wrapper commands** — they run without spawning a full Studio session and work with the hardened compose file:
 
 ```bash
-$COMPOSE run --rm hck-cli version
+$COMPOSE run --rm hck-cli                       # default: version
 $COMPOSE run --rm hck-cli showLicense
 $COMPOSE run --rm hck-cli listLogs
 $COMPOSE run --rm hck-cli showLogs --logfile license
@@ -247,11 +275,11 @@ $COMPOSE run --rm hck-cli showLogs --logfile license
 
 ```bash
 $COMPOSE pull
-$COMPOSE run --rm hck-cli version
+$COMPOSE run --rm hck-cli                       # version + plugin list
 $COMPOSE run --rm hck-cli showLicense          # before: missing / wrong image id
 
-$COMPOSE run --rm showComputerIdForOfflineValidation
-# … LicenseFile.xml on a connected machine …
+$COMPOSE run --rm showComputerIdForOfflineValidation   # Computer ID + QLM URL → download LicenseFile.xml
+# … copy LicenseFile.xml to the server …
 $COMPOSE run --rm validateKeyOffline
 $COMPOSE run --rm hck-cli showLicense          # after: installed
 
@@ -267,7 +295,7 @@ $COMPOSE run --rm hck-cli genDoc …
 | Step | Compose service | Notes |
 | --- | --- | --- |
 | Version / RE / FE / docs | `hck-cli` | Pass command as container `command` or CLI args |
-| Computer ID | `showComputerIdForOfflineValidation` | |
+| Computer ID + QLM URL | `showComputerIdForOfflineValidation` | Opens prefilled URL on a connected machine to download `LicenseFile.xml` |
 | Offline license | `validateKeyOffline` | `network_mode: none` + secret |
 
 Same **`/data` + `/tmp`** layout as [`compose.yml`](../compose.yml) and [`k8s/`](../k8s/) — hardened only adds read-only rootfs and dropped capabilities.

--- a/Studio/doc/getting-started-hck-cli.md
+++ b/Studio/doc/getting-started-hck-cli.md
@@ -15,20 +15,26 @@ Ready-to-use Docker image: Hackolade Studio CLI, all target plugins, no build st
 | **[Kubernetes](../k8s/README.md)** | Running on K8s / OpenShift |
 | **[Custom TLS certificates](./custom-certificates.md)** | Private CAs with read-only PEM mounts |
 
-## Runtime model (all deployments)
+## Writable paths — `/data` and `/tmp` only
 
-Every `hackolade/hck-cli` container uses the **same consolidated write layout** — whether you enable a read-only root filesystem or not. Runtime state is not scattered under `/home/hackolade/...` anymore.
+> **Rule:** `hackolade/hck-cli` performs **all runtime writes** to **`/data`** and **`/tmp`** — **nowhere else**.
 
-**Exactly two writable locations:**
+The image no longer scatters state under `/home/hackolade/...`. Environment variables (XDG base dirs, `DATA_DIR`, `TMPDIR`, …) steer every write to these two mounts. This applies in **every** deployment profile — local Compose, hardened Compose, Kubernetes, and plain `docker run`.
 
-| Mount | Backing | Holds |
+| Path | What gets written there | Persists? |
 | --- | --- | --- |
-| **`/data`** | Named volume or PVC | License state (`/data/app`), models, output, logs, settings |
-| **`/tmp`** | tmpfs or memory `emptyDir` | Sockets, caches, scratch (ephemeral) |
+| **`/data`** | License/userData (`/data/app`), command logs (`/data/logs`), models, forward/reverse-engineering output, settings | Yes — use a named volume or PVC |
+| **`/tmp`** | Unix sockets, plugin caches, Electron/Chromium scratch, XDG runtime dir | No — tmpfs or memory `emptyDir` |
 
-Everything persistent lives under **`/data`**. Everything transient goes to **`/tmp`**.
+**Do not mount or expect writes to:**
 
-This is the same layout in [`compose.yml`](../compose.yml), [`compose.hardened.yml`](../compose.hardened.yml), and the [`k8s/`](../k8s/) Job manifests — only the **security profile** changes.
+- `/home/hackolade/.config/Hackolade` (legacy license path — **removed**)
+- `/home/hackolade/Documents/HackoladeLogs`, `/home/hackolade/Documents/data`, … (legacy layout)
+- Any other bind mount you add outside `/data` or `/tmp`
+
+Put host folders **under `/data`** (e.g. `${PWD}/models:/data/models`). With **`read_only: true`**, the root filesystem is read-only — writes outside `/data` or `/tmp` **fail**.
+
+This is the same rule in [`compose.yml`](../compose.yml), [`compose.hardened.yml`](../compose.hardened.yml), and [`k8s/`](../k8s/) — only the **security profile** (read-only rootfs, caps, user) changes.
 
 ## Deployment profiles
 
@@ -51,7 +57,7 @@ OpenShift arbitrary UID: [`compose.hardened.yml`](../compose.hardened.yml) (`hck
 - **Floating license only** — workstation licenses do not work in Docker.
 - **Pin a version tag** — `latest` is not published. Example: `hackolade/hck-cli:8.12.7`. Weekly plugin refreshes may appear as `8.12.7-YYYY-MM-DD` on the [current release only](https://hub.docker.com/r/hackolade/hck-cli/tags).
 - **Re-validate when the image tag changes** — license state is tied to the image UUID.
-- **Mount `/data` and `/tmp` on every run** — required when `read_only: true`; use the same layout even when the root filesystem is writable.
+- **Mount `/data` and `/tmp` on every run** — the image writes **only** to these two paths; nothing else receives runtime data (see [Writable paths](#writable-paths-data-and-tmp-only)).
 - **Always use `docker compose run --rm`** — removes the one-off container when the command exits. Without `--rm`, stopped `…-run-…` containers accumulate and Compose warns about **orphan containers** on the next run.
 
 Need a custom plugin set or your own Dockerfile? See [getting-started.md](./getting-started.md) (legacy `hackolade/studio` build path).
@@ -154,7 +160,8 @@ See **[docker-cli-howto.md](./docker-cli-howto.md)** for local and hardened `doc
 | Problem | Check |
 | --- | --- |
 | Permission denied on `./models` | `chown -R 1000:1001 ./models` |
-| Fails with read-only rootfs | Writable `/tmp` tmpfs is mounted |
+| Fails with read-only rootfs | Both **`/data`** (volume) and **`/tmp`** (tmpfs) must be mounted — the image writes nowhere else |
+| `Read-only file system` / permission denied outside `/data` | Expected — mount the path under **`/data/…`** instead of `/home/hackolade/…` |
 | License validation fails | Same image tag for UUID + validation; floating seat available |
 | Secret not found | Paths in compose `secrets:` match files on disk |
 | Unsure if license is valid | `hck-cli showLicense` or `showLicense --json` |

--- a/Studio/doc/getting-started-hck-cli.md
+++ b/Studio/doc/getting-started-hck-cli.md
@@ -51,7 +51,7 @@ OpenShift arbitrary UID: [`compose.hardened.yml`](../compose.hardened.yml) (`hck
 - **Floating license only** — workstation licenses do not work in Docker.
 - **Pin a version tag** — `latest` is not published. Example: `hackolade/hck-cli:8.12.7`. Weekly plugin refreshes may appear as `8.12.7-YYYY-MM-DD` on the [current release only](https://hub.docker.com/r/hackolade/hck-cli/tags).
 - **Re-validate when the image tag changes** — license state is tied to the image UUID.
-- **Mount `/data` and `/tmp` on every run** — the image writes **only** to these two paths; nothing else receives runtime data (see [Writable paths](#writable-paths-data-and-tmp-recommended)).
+- **Mount `/data` and `/tmp` on every run** — recommended consolidated layout; legacy `/home/hackolade/…` bind mounts may still work on a writable rootfs (see [Writable paths](#writable-paths-data-and-tmp-recommended)).
 - **Always use `docker compose run --rm`** — removes the one-off container when the command exits. Without `--rm`, stopped `…-run-…` containers accumulate and Compose warns about **orphan containers** on the next run.
 
 Need a custom plugin set or your own Dockerfile? See [getting-started.md](./getting-started.md) (legacy `hackolade/studio` build path).

--- a/Studio/doc/getting-started-hck-cli.md
+++ b/Studio/doc/getting-started-hck-cli.md
@@ -15,24 +15,18 @@ Ready-to-use Docker image: Hackolade Studio CLI, all target plugins, no build st
 | **[Kubernetes](../k8s/README.md)** | Running on K8s / OpenShift |
 | **[Custom TLS certificates](./custom-certificates.md)** | Private CAs with read-only PEM mounts |
 
-## Writable paths — `/data` and `/tmp` only
+## Writable paths — `/data` and `/tmp` (recommended)
 
-> **Rule:** `hackolade/hck-cli` performs **all runtime writes** to **`/data`** and **`/tmp`** — **nowhere else**.
-
-The image no longer scatters state under `/home/hackolade/...`. Environment variables (XDG base dirs, `DATA_DIR`, `TMPDIR`, …) steer every write to these two mounts. This applies in **every** deployment profile — local Compose, hardened Compose, Kubernetes, and plain `docker run`.
+> **Recommended:** mount **`/data`** and **`/tmp`** — the image steers **all runtime writes** there via XDG environment variables (`DATA_DIR`, `TMPDIR`, …).
 
 | Path | What gets written there | Persists? |
 | --- | --- | --- |
 | **`/data`** | License/userData (`/data/app`), command logs (`/data/logs`), models, forward/reverse-engineering output, settings | Yes — use a named volume or PVC |
 | **`/tmp`** | Unix sockets, plugin caches, Electron/Chromium scratch, XDG runtime dir | No — tmpfs or memory `emptyDir` |
 
-**Do not mount or expect writes to:**
+**Legacy paths** (older examples and custom-built images) used mounts such as `/home/hackolade/.config/Hackolade`, `/home/hackolade/Documents/HackoladeLogs`, and `/home/hackolade/Documents/data`. Those bind mounts **can still work** on a writable root filesystem if you keep using them, but **prefer the consolidated `/data` + `/tmp` layout** — fewer volumes, same paths in Compose and Kubernetes, and required for read-only rootfs.
 
-- `/home/hackolade/.config/Hackolade` (legacy license path — **removed**)
-- `/home/hackolade/Documents/HackoladeLogs`, `/home/hackolade/Documents/data`, … (legacy layout)
-- Any other bind mount you add outside `/data` or `/tmp`
-
-Put host folders **under `/data`** (e.g. `${PWD}/models:/data/models`). With **`read_only: true`**, the root filesystem is read-only — writes outside `/data` or `/tmp` **fail**.
+Put host folders **under `/data`** (e.g. `${PWD}/models:/data/models`). With **`read_only: true`**, only **`/data`** and **`/tmp`** are writable; legacy paths on the root filesystem will not receive new writes.
 
 This is the same rule in [`compose.yml`](../compose.yml), [`compose.hardened.yml`](../compose.hardened.yml), and [`k8s/`](../k8s/) — only the **security profile** (read-only rootfs, caps, user) changes.
 
@@ -57,7 +51,7 @@ OpenShift arbitrary UID: [`compose.hardened.yml`](../compose.hardened.yml) (`hck
 - **Floating license only** — workstation licenses do not work in Docker.
 - **Pin a version tag** — `latest` is not published. Example: `hackolade/hck-cli:8.12.7`. Weekly plugin refreshes may appear as `8.12.7-YYYY-MM-DD` on the [current release only](https://hub.docker.com/r/hackolade/hck-cli/tags).
 - **Re-validate when the image tag changes** — license state is tied to the image UUID.
-- **Mount `/data` and `/tmp` on every run** — the image writes **only** to these two paths; nothing else receives runtime data (see [Writable paths](#writable-paths-data-and-tmp-only)).
+- **Mount `/data` and `/tmp` on every run** — the image writes **only** to these two paths; nothing else receives runtime data (see [Writable paths](#writable-paths-data-and-tmp-recommended)).
 - **Always use `docker compose run --rm`** — removes the one-off container when the command exits. Without `--rm`, stopped `…-run-…` containers accumulate and Compose warns about **orphan containers** on the next run.
 
 Need a custom plugin set or your own Dockerfile? See [getting-started.md](./getting-started.md) (legacy `hackolade/studio` build path).
@@ -160,8 +154,8 @@ See **[docker-cli-howto.md](./docker-cli-howto.md)** for local and hardened `doc
 | Problem | Check |
 | --- | --- |
 | Permission denied on `./models` | `chown -R 1000:1001 ./models` |
-| Fails with read-only rootfs | Both **`/data`** (volume) and **`/tmp`** (tmpfs) must be mounted — the image writes nowhere else |
-| `Read-only file system` / permission denied outside `/data` | Expected — mount the path under **`/data/…`** instead of `/home/hackolade/…` |
+| Fails with read-only rootfs | Mount **`/data`** (volume) and **`/tmp`** (tmpfs) — with `read_only: true`, only these paths are writable |
+| `Read-only file system` / writes not landing on a legacy mount | Prefer **`/data/…`** — the image redirects runtime writes to `/data` and `/tmp`; legacy `/home/hackolade/…` bind mounts may still work on a writable rootfs but are not recommended |
 | License validation fails | Same image tag for UUID + validation; floating seat available |
 | Secret not found | Paths in compose `secrets:` match files on disk |
 | Unsure if license is valid | `hck-cli showLicense` or `showLicense --json` |

--- a/Studio/doc/getting-started-hck-cli.md
+++ b/Studio/doc/getting-started-hck-cli.md
@@ -4,6 +4,17 @@ Ready-to-use Docker image: Hackolade Studio CLI, all target plugins, no build st
 
 ![Docker Image Version (latest by date)](https://img.shields.io/docker/v/hackolade/hck-cli)
 
+## Guides
+
+| Guide | Use when |
+| --- | --- |
+| **This page** | First run, deployment profiles, troubleshooting |
+| **[Offline pipeline example](./example-offline-metadata-pipeline.md)** | **Complete CI story** — new image tag, offline license, revEng → compMod → DDL → docs, plus `version`, `showLicense`, `listLogs`, `showLogs` |
+| **[Docker CLI how-to](./docker-cli-howto.md)** | You prefer **`docker run`** instead of Compose |
+| **[License validation](./license-validation.md)** | Online or offline floating license setup |
+| **[Kubernetes](../k8s/README.md)** | Running on K8s / OpenShift |
+| **[Custom TLS certificates](./custom-certificates.md)** | Private CAs with read-only PEM mounts |
+
 ## Runtime model (all deployments)
 
 Every `hackolade/hck-cli` container uses the **same consolidated write layout** — whether you enable a read-only root filesystem or not. Runtime state is not scattered under `/home/hackolade/...` anymore.
@@ -29,7 +40,8 @@ This is the same layout in [`compose.yml`](../compose.yml), [`compose.hardened.y
 
 ```bash
 # Hardened smoke test (recommended baseline for pipelines)
-docker compose -f compose.hardened.yml run --rm hck-cli version
+# `version` is the default command — explicit `version` arg is optional
+docker compose -f compose.hardened.yml run --rm hck-cli
 ```
 
 OpenShift arbitrary UID: [`compose.hardened.yml`](../compose.hardened.yml) (`hck-cli-arbitrary-uid`) or [`k8s/hck-cli-job-openshift.yaml`](../k8s/hck-cli-job-openshift.yaml).
@@ -40,6 +52,7 @@ OpenShift arbitrary UID: [`compose.hardened.yml`](../compose.hardened.yml) (`hck
 - **Pin a version tag** — `latest` is not published. Example: `hackolade/hck-cli:8.12.7`. Weekly plugin refreshes may appear as `8.12.7-YYYY-MM-DD` on the [current release only](https://hub.docker.com/r/hackolade/hck-cli/tags).
 - **Re-validate when the image tag changes** — license state is tied to the image UUID.
 - **Mount `/data` and `/tmp` on every run** — required when `read_only: true`; use the same layout even when the root filesystem is writable.
+- **Always use `docker compose run --rm`** — removes the one-off container when the command exits. Without `--rm`, stopped `…-run-…` containers accumulate and Compose warns about **orphan containers** on the next run.
 
 Need a custom plugin set or your own Dockerfile? See [getting-started.md](./getting-started.md) (legacy `hackolade/studio` build path).
 
@@ -52,11 +65,24 @@ cp compose.hardened.yml compose.local.yml   # or compose.yml for a minimal local
 mkdir -p ./models
 ```
 
-2. Pull and check the image:
+2. Pull and check the image (`version` is the default service command):
 
 ```bash
 docker compose -f compose.local.yml pull
-docker compose -f compose.local.yml run --rm hck-cli version
+docker compose -f compose.local.yml run --rm hck-cli
+```
+
+Expect **Hackolade version** plus **Installed plugins** with version, commit, and build date for each bundled plugin:
+
+```text
+detected containerized environment and allowed command
+
+Hackolade version: 8.12.7
+
+Installed plugins (40):
+  Avro: 0.2.27, commit: d0fda00f, built: 2026-07-03T13:26:23+0000
+  BigQuery: 0.2.30, commit: 04fb1148, built: 2026-08-07T09:04:23+0000
+  …
 ```
 
 3. Validate your license (online — adjust secret paths in the compose file):
@@ -76,9 +102,9 @@ docker compose -f compose.local.yml run --rm hck-cli genDoc \
   --doc /data/output/doc
 ```
 
-Offline validation: [license-validation.md](./license-validation.md).
+Offline validation: run **`showComputerIdForOfflineValidation`** — it prints the Computer ID and a **ready-to-open QLM URL** (`is_file=1`, prefilled `is_pcid` and `is_avkey` when `license_key` is configured). Open the URL on a connected machine to download **`LicenseFile.xml`**, then run **`validateKeyOffline`**. Details: [license-validation.md](./license-validation.md).
 
-**Full pipeline story** (new image, offline license, revEng → compMod → DDL → docs with `version`, `showLicense`, `listLogs`, `showLogs`): [example-offline-metadata-pipeline.md](./example-offline-metadata-pipeline.md).
+**Next:** follow the **[offline metadata pipeline example](./example-offline-metadata-pipeline.md)** for a full hardened Compose walkthrough (image upgrade, offline license, revEng → compMod → forweng → genDoc, diagnostics).
 
 ## Inspecting the image, license, and logs
 
@@ -86,7 +112,7 @@ Wrapper commands handled by `hck-cli` itself (no full Studio session). Use them 
 
 | Command | Purpose |
 | --- | --- |
-| `version` | Studio/CLI build in the image |
+| `version` | Studio release in the image + full plugin inventory (name, version, commit, build date) |
 | `showLicense` | License installed and valid for **this** image tag? (`--json` for scripts; exit 0 = OK) |
 | `listLogs` | List command runs under `/data/logs` (newest first) |
 | `showLogs [runId] [--tail N] [--logfile main\|re\|fe\|license]` | Tail logs for one run |
@@ -94,7 +120,7 @@ Wrapper commands handled by `hck-cli` itself (no full Studio session). Use them 
 ```bash
 export COMPOSE="docker compose -f compose.hardened.yml"
 
-$COMPOSE run --rm hck-cli version
+$COMPOSE run --rm hck-cli                    # default command: version
 $COMPOSE run --rm hck-cli showLicense
 $COMPOSE run --rm hck-cli showLicense --json
 $COMPOSE run --rm hck-cli listLogs
@@ -121,17 +147,7 @@ Update the `image:` line in your compose file, then `docker compose pull`.
 
 ## Docker CLI (without Compose)
 
-Minimal `docker run` example (same `/data` + `/tmp` layout). For a full **`docker run`** reference, mirror the commands in [example-offline-metadata-pipeline.md](./example-offline-metadata-pipeline.md) and [getting-started-hck-cli.md](./getting-started-hck-cli.md).
-
-```bash
-docker volume create hackolade-studio-data
-
-docker run --rm \
-  -v hackolade-studio-data:/data \
-  -v "${PWD}/models:/data/models" \
-  --tmpfs /tmp:rw,size=1g,mode=1777 \
-  hackolade/hck-cli:8.12.7 version
-```
+See **[docker-cli-howto.md](./docker-cli-howto.md)** for local and hardened `docker run` templates, diagnostics, and artifact extraction.
 
 ## Troubleshooting
 
@@ -143,12 +159,14 @@ docker run --rm \
 | Secret not found | Paths in compose `secrets:` match files on disk |
 | Unsure if license is valid | `hck-cli showLicense` or `showLicense --json` |
 | Command failed in CI | `hck-cli listLogs` then `showLogs <runId> --logfile re` |
+| `Found orphan containers` warning | Past runs without `--rm`; use `docker compose run --rm …` always, then `docker compose -f compose.hardened.yml down --remove-orphans` to clean up |
 
 ## See also
 
-- [Example: offline metadata pipeline](./example-offline-metadata-pipeline.md) — hardened Compose walkthrough
+- [Offline metadata pipeline example](./example-offline-metadata-pipeline.md) — **full CI walkthrough**
+- [Docker CLI how-to](./docker-cli-howto.md)
 - [License validation](./license-validation.md)
-- [Custom TLS certificates](./custom-certificates.md) (read-only PEM mounts — works with hardened / K8s)
+- [Custom TLS certificates](./custom-certificates.md)
 - [Kubernetes examples](../k8s/README.md)
 - [Build your own image](./getting-started.md)
 - [Hackolade CLI command reference](https://hackolade.com/help/CommandLineInterface.html)

--- a/Studio/doc/license-validation.md
+++ b/Studio/doc/license-validation.md
@@ -2,9 +2,70 @@
 
 Before you can use Hackolade Studio CLI in Docker, you must validate your floating license key, a.k.a. concurrent license key. This process links your license to the specific Docker image you built.
 
-**Important:** You need a **floating license key** (not a workstation license) to use Hackolade in Docker. The license validation must be repeated for each new Docker image you build, as each image has a unique identifier.
+**Important:** You need a **floating license key** (not a workstation license) to use Hackolade in Docker. The license validation must be repeated for each new Docker image you use, as each image has a unique identifier.
 
+## Pre-built `hackolade/hck-cli` (recommended)
 
+Use [`compose.yml`](../compose.yml) or [`compose.hardened.yml`](../compose.hardened.yml). Configure secrets in the compose file (`license_key`, `license_file`).
+
+**Always pass `--rm`** on `docker compose run` so one-off containers are removed when the command exits (avoids orphan-container warnings).
+
+| Service | Command | When |
+| --- | --- | --- |
+| `validateKeyOnline` | `validateKey` | Server has Internet |
+| `showComputerIdForOfflineValidation` | `getComputerId` | Air-gapped server — prints Computer ID + QLM URL |
+| `validateKeyOffline` | `validateKey` | After `LicenseFile.xml` is on the server |
+
+Full walkthrough: [example-offline-metadata-pipeline.md](./example-offline-metadata-pipeline.md).
+
+### Online (Compose)
+
+```bash
+echo "YOUR-FLOATING-LICENSE-KEY" > ~/license-key.txt
+chmod 600 ~/license-key.txt
+docker compose -f compose.hardened.yml run --rm validateKeyOnline
+```
+
+Confirm with `docker compose -f compose.hardened.yml run --rm hck-cli showLicense`.
+
+### Offline (Compose)
+
+**Step 1 — on the air-gapped server:** get Computer ID and QLM URL:
+
+```bash
+docker compose -f compose.hardened.yml run --rm showComputerIdForOfflineValidation
+```
+
+Example output:
+
+```text
+📋 Copy the Computer ID below and use it for offline license activation:
+
+afa10d9e-17cd-48d7-97f5-b277951773ec-b572e4e5-6796-4cf7-820e-62a30530a318-8.12.7-docker
+
+🌐 Open the following URL in your browser to proceed with offline validation:
+   https://quicklicensemanager.com/hackolade/qlmcustomersite/qlmwebactivation.aspx?is_file=1&is_pcid=afa10d9e-17cd-48d7-97f5-b277951773ec-b572e4e5-6796-4cf7-820e-62a30530a318-8.12.7-docker&is_avkey=YOUR-FLOATING-LICENSE-KEY
+   (activation key prefilled from license key / secrets)
+```
+
+The Computer ID is `<image-uuid>-<container-uuid>-<studio-version>-docker`. The URL prefills **`is_file=1`** (download `LicenseFile.xml`), **`is_pcid`**, and **`is_avkey`** when the `license_key` secret is set — copy the URL to a machine with Internet access.
+
+**Step 2 — on an Internet-connected machine:** open that URL in a browser. QLM downloads **`LicenseFile.xml`** automatically. **Do not edit** the file.
+
+**Step 3 — copy** `LicenseFile.xml` to the path in compose (`secrets.license_file`, default `${HOME}/Downloads/LicenseFile.xml`).
+
+**Step 4 — validate on the server:**
+
+```bash
+docker compose -f compose.hardened.yml run --rm validateKeyOffline
+docker compose -f compose.hardened.yml run --rm hck-cli showLicense
+```
+
+---
+
+## Legacy custom-built images
+
+The sections below describe the older `hackolade/studio` build path (`show-computer-id.sh`, `/home/hackolade/.config/Hackolade` volumes).
 
 ## Online License Validation (With Internet Connection)
 

--- a/Studio/k8s/README.md
+++ b/Studio/k8s/README.md
@@ -1,13 +1,15 @@
 # Kubernetes examples for `hackolade/hck-cli`
 
-## Writable paths — `/data` and `/tmp` only
+## Writable paths — `/data` and `/tmp` (recommended)
 
-The image writes runtime data **only** to **`/data`** (PVC) and **`/tmp`** (memory `emptyDir`). **No other path** receives writes — not `/home/hackolade/...`, not anywhere on the read-only root filesystem.
+Runtime writes are steered to **`/data`** (PVC) and **`/tmp`** (memory `emptyDir`). **Use these consolidated mounts** — they match Compose examples and are required with `readOnlyRootFilesystem`.
 
 | Mount | Backing | Holds |
 | --- | --- | --- |
 | `/data` | PVC | License state (`/data/app`), models, output, logs |
-| `/tmp` | memory `emptyDir` | Scratch, sockets, caches (required with `readOnlyRootFilesystem`) |
+| `/tmp` | memory `emptyDir` | Scratch, sockets, caches |
+
+Legacy `/home/hackolade/…` bind mounts from older Docker setups are not used here; prefer `/data` subpaths instead.
 
 Same rule as [`compose.yml`](../compose.yml) and [`compose.hardened.yml`](../compose.hardened.yml). These manifests add the **hardened profile**: read-only root filesystem, non-root, dropped capabilities (Kubernetes **Restricted** Pod Security Standard).
 

--- a/Studio/k8s/README.md
+++ b/Studio/k8s/README.md
@@ -1,13 +1,15 @@
 # Kubernetes examples for `hackolade/hck-cli`
 
-Same **consolidated write layout** as [`compose.yml`](../compose.yml) and [`compose.hardened.yml`](../compose.hardened.yml):
+## Writable paths — `/data` and `/tmp` only
+
+The image writes runtime data **only** to **`/data`** (PVC) and **`/tmp`** (memory `emptyDir`). **No other path** receives writes — not `/home/hackolade/...`, not anywhere on the read-only root filesystem.
 
 | Mount | Backing | Holds |
 | --- | --- | --- |
-| `/data` | PVC | License state, models, output, logs |
-| `/tmp` | memory `emptyDir` | Scratch (required with `readOnlyRootFilesystem`) |
+| `/data` | PVC | License state (`/data/app`), models, output, logs |
+| `/tmp` | memory `emptyDir` | Scratch, sockets, caches (required with `readOnlyRootFilesystem`) |
 
-These manifests add the **hardened profile**: read-only root filesystem, non-root, dropped capabilities (Kubernetes **Restricted** Pod Security Standard).
+Same rule as [`compose.yml`](../compose.yml) and [`compose.hardened.yml`](../compose.hardened.yml). These manifests add the **hardened profile**: read-only root filesystem, non-root, dropped capabilities (Kubernetes **Restricted** Pod Security Standard).
 
 Pin the image tag in each manifest (default: `hackolade/hck-cli:8.12.7`).
 

--- a/Studio/k8s/hck-cli-gendoc-job.yaml
+++ b/Studio/k8s/hck-cli-gendoc-job.yaml
@@ -1,5 +1,7 @@
 # Generate documentation under a hardened Job — same security posture as hck-cli-job.yaml.
 #
+# WRITABLE PATHS: /data and /tmp ONLY — runtime writes go nowhere else.
+#
 # Place a model at /data/models/smoke.hck.json on the hck-cli-data PVC before running
 # (kubectl cp, an init container, or a CI step that seeds the volume).
 #

--- a/Studio/k8s/hck-cli-job-openshift.yaml
+++ b/Studio/k8s/hck-cli-job-openshift.yaml
@@ -1,5 +1,7 @@
 # OpenShift restricted-v2 variant: arbitrary UID in the root supplementary group.
 #
+# WRITABLE PATHS: /data and /tmp ONLY — same as hck-cli-job.yaml.
+#
 # OpenShift assigns a random UID with no /etc/passwd entry. The image handles this
 # via nss_wrapper when /data is group-writable (fsGroup: 0 matches image ownership).
 #

--- a/Studio/k8s/hck-cli-job.yaml
+++ b/Studio/k8s/hck-cli-job.yaml
@@ -1,7 +1,7 @@
 # Hardened Kubernetes Job for hackolade/hck-cli (Restricted Pod Security Standard).
 #
-# Writable mounts:
-#   /data  — PersistentVolumeClaim (license state, logs, models, output)
+# WRITABLE PATHS: /data and /tmp ONLY — runtime writes go nowhere else.
+#   /data  — PersistentVolumeClaim (license /data/app, logs, models, output)
 #   /tmp   — emptyDir backed by memory (tmpfs equivalent, 1 GiB limit)
 #
 # Apply:


### PR DESCRIPTION
## Summary

- Turn root and Studio READMEs into a **docs hub** (no duplicated runtime-model content)
- Add **[docker-cli-howto.md](Studio/doc/docker-cli-howto.md)** for `docker run` templates
- Document **`getComputerId` / `showComputerIdForOfflineValidation`**: prefilled QLM URL for `LicenseFile.xml` download
- Document **`version`** output (Studio release + full plugin list)
- Advise **`docker compose run --rm`** everywhere to avoid orphan-container warnings

## Test plan

- [x] README links resolve on GitHub
- [x] Compose smoke test: `docker compose -f Studio/compose.hardened.yml run --rm hck-cli`
- [x] Offline flow: `showComputerIdForOfflineValidation` prints QLM URL


Made with [Cursor](https://cursor.com)